### PR TITLE
Avoid using the ambiguous \h shorthand character

### DIFF
--- a/Opal.YAML-tmLanguage
+++ b/Opal.YAML-tmLanguage
@@ -227,7 +227,7 @@ repository:
       match: \"[+-]?\d*(\.\d*)?(e[+-]?\d+)?\"!
       # https://projects.uebb.tu-berlin.de/opal/dosfop/2.4a/bibopalicaman/Real.html
     - name: constant.numeric.hexadecimal.opal
-      match: \"0x\h+\"!
+      match: \"0x[0-9A-Fa-f]+\"!
 
     # strings (denotation)
     - name: string.quoted.double.opal

--- a/Opal.tmLanguage
+++ b/Opal.tmLanguage
@@ -491,7 +491,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\"0x\h+\"!</string>
+					<string>\"0x[0-9A-Fa-f]+\"!</string>
 					<key>name</key>
 					<string>constant.numeric.hexadecimal.opal</string>
 				</dict>


### PR DESCRIPTION
Depending on the regular expression engine used, \h does not always
mean the same. With a PCRE engine, it matches white spaces, whereas,
with a Oniguruma engine, it matches hexademical digit characters.
Sublime Text uses an Oniguruma engine, but github.com relies on a
PCRE engine.